### PR TITLE
feat: add lineage computation to the renku tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -174,6 +174,24 @@
         }
       }
     },
+    "@jupyterlab/docmanager": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/docmanager/-/docmanager-0.19.1.tgz",
+      "integrity": "sha512-yIT4wQIja2ppNDN7Hrpp6VUavv65Im49XFrhXfWqV4wpmT2NBHqYPVviARqzuXmPRgz3ck/GhQW/DgG9bu4ulw==",
+      "requires": {
+        "@jupyterlab/apputils": "^0.19.1",
+        "@jupyterlab/coreutils": "^2.2.1",
+        "@jupyterlab/docregistry": "^0.19.1",
+        "@jupyterlab/services": "^3.2.1",
+        "@phosphor/algorithm": "^1.1.2",
+        "@phosphor/coreutils": "^1.3.0",
+        "@phosphor/disposable": "^1.1.2",
+        "@phosphor/messaging": "^1.2.2",
+        "@phosphor/properties": "^1.1.2",
+        "@phosphor/signaling": "^1.2.2",
+        "@phosphor/widgets": "^1.6.0"
+      }
+    },
     "@jupyterlab/docregistry": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@jupyterlab/docregistry/-/docregistry-0.19.1.tgz",
@@ -190,6 +208,27 @@
         "@phosphor/algorithm": "^1.1.2",
         "@phosphor/coreutils": "^1.3.0",
         "@phosphor/disposable": "^1.1.2",
+        "@phosphor/messaging": "^1.2.2",
+        "@phosphor/signaling": "^1.2.2",
+        "@phosphor/widgets": "^1.6.0"
+      }
+    },
+    "@jupyterlab/filebrowser": {
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/filebrowser/-/filebrowser-0.19.4.tgz",
+      "integrity": "sha512-eUBxpBejh+EK6toLciwzuMt/6LIo2QikcjyTgKZQF1gNY1ZBqR2x2VTVSCPm2A5qro2/oEBJoqQZ4ZGlxmtvxQ==",
+      "requires": {
+        "@jupyterlab/apputils": "^0.19.1",
+        "@jupyterlab/coreutils": "^2.2.1",
+        "@jupyterlab/docmanager": "^0.19.1",
+        "@jupyterlab/docregistry": "^0.19.1",
+        "@jupyterlab/services": "^3.2.1",
+        "@phosphor/algorithm": "^1.1.2",
+        "@phosphor/commands": "^1.6.1",
+        "@phosphor/coreutils": "^1.3.0",
+        "@phosphor/disposable": "^1.1.2",
+        "@phosphor/domutils": "^1.1.2",
+        "@phosphor/dragdrop": "^1.3.0",
         "@phosphor/messaging": "^1.2.2",
         "@phosphor/signaling": "^1.2.2",
         "@phosphor/widgets": "^1.6.0"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
   "dependencies": {
     "@jupyterlab/application": "^0.19.1",
     "@jupyterlab/apputils": "^0.19.1",
+    "@jupyterlab/docmanager": "^0.19.1",
+    "@jupyterlab/filebrowser": "^0.19.4",
     "@jupyterlab/notebook": "^0.19.2",
     "@jupyterlab/terminal": "^0.19.1",
     "@types/react-dom": "^16.4.2",

--- a/src/RenkuCommands.tsx
+++ b/src/RenkuCommands.tsx
@@ -8,11 +8,14 @@ import { INotebookTracker } from '@jupyterlab/notebook';
 import AboutCommand from './help/AboutCommand';
 import HelpCommand from './help/HelpCommand';
 import CheatSheetCommand from './help/CheatSheetCommand';
+import { DocumentManager } from '@jupyterlab/docmanager';
+import { RenkuGraph } from './RenkuGraph'
 
 export interface IRenkuCommands {
     app: JupyterLab;
     notebooks: INotebookTracker;
     terminalManager: RenkuTerminalManager;
+    docManager?: DocumentManager;
 };
 
 class RenkuCommands extends React.Component<IRenkuCommands>{
@@ -90,6 +93,10 @@ class RenkuCommands extends React.Component<IRenkuCommands>{
                     arguments={[{id:"url", label:"Url", arg:"-h", type:"text" , value:""},
                         {id:"doi",  label:"DOI", arg:"-h", type:"text" , value:""}]} /> */}
 
+                <RenkuGraph
+                    app={this.props.app}
+                    terminalManager={this.props.terminalManager}
+                    docManager={this.props.docManager} />
             </ul>
         );
     };

--- a/src/RenkuGraph.tsx
+++ b/src/RenkuGraph.tsx
@@ -1,0 +1,172 @@
+import * as React from 'react';
+
+import RenkuTerminalManager from './RenkuTerminalManager';
+import { JupyterLab } from '@jupyterlab/application';
+import { MessageLoop } from '@phosphor/messaging';
+import { FileBrowser, DirListing } from '@jupyterlab/filebrowser';
+import { DocumentManager } from '@jupyterlab/docmanager';
+
+export interface IRenkuGraphProps {
+    app: JupyterLab;
+    terminalManager: RenkuTerminalManager;
+    docManager: DocumentManager;
+};
+
+interface IRenkuGraphState {
+    visible: boolean;
+    computing: boolean;
+    error: string;
+    currentFile: any;
+    loopCounter: number;
+}
+
+const RENKU_GRAPH_PATH = ".git/renkuLineage.svg";
+
+class RenkuGraph extends React.Component<IRenkuGraphProps, IRenkuGraphState> {
+    constructor(props: IRenkuGraphProps) {
+        super(props);
+        this.state = {
+            visible: false,
+            computing: false,
+            error: null,
+            currentFile: null,
+            loopCounter: 0
+        }
+
+        // create hook to get selected file data
+        let fileBrowser;
+        const leftWidgets = this.props.app.shell.widgets("left");
+        for (let current = leftWidgets.next(); current !== undefined; current = leftWidgets.next()) {
+            if (current.id === "filebrowser") {
+                fileBrowser = current as FileBrowser;
+                break;
+            }
+        }
+        const dirlisting = fileBrowser["_listing"] as DirListing;
+        this.createFileBrowserHook(dirlisting);
+
+        // bindings
+        this.toggleVisibility = this.toggleVisibility.bind(this);
+        this.activateFileBrowser = this.activateFileBrowser.bind(this);
+        this.graphGenerator = this.graphGenerator.bind(this);
+    }
+
+    toggleVisibility() {
+        this.setState({ visible: !this.state.visible });
+    }
+
+    activateFileBrowser() {
+        if (!this.state.computing) {
+            this.props.app.shell.activateById("filebrowser");
+        } 
+    }
+
+    createFileBrowserHook(dirListing: DirListing) {
+        MessageLoop.installMessageHook(dirListing, () => {
+            // consider only the last selected item for multi-selection.
+            const { currentFile } = this.state;
+            const newFile = dirListing.selectedItems().next();
+            if (!newFile) {
+                if (this.state.currentFile !== null) {
+                    this.setState({ "currentFile" : null, "error": null });
+                }
+                return true;
+            }
+            if (currentFile === null || newFile.path !== currentFile.path) {
+                this.setState({ "currentFile": newFile, "error": null });
+            }
+            return true;
+        });
+    }
+
+    graphGenerator() {
+        const { currentFile } = this.state;
+        if (currentFile === null || currentFile.type === "directory") {
+            this.setState({ error: "invalid input file" });
+            return;
+        }
+        if (this.state.error !== null) {
+            this.setState({ error: null });
+        }
+        this.setState({ computing: true });
+        this.props.docManager.deleteFile(RENKU_GRAPH_PATH)
+            .then(data => { this.createGraph(currentFile.path, RENKU_GRAPH_PATH)})
+            .catch(error => { this.createGraph(currentFile.path, RENKU_GRAPH_PATH)});
+    }
+
+    createGraph(currentPath: string, outputPath: string) {
+        const fullCurrentPath = this.buildFullPath(currentPath);
+        const fullOutputPath = this.buildFullPath(outputPath);
+        const command = "renku log --format dot " + fullCurrentPath + " | dot -Tsvg -o " + fullOutputPath;
+        this.props.terminalManager.runCommand(command)
+            .then(data => {
+                this.setState({loopCounter: 0});
+                this.openGraphLoop(fullOutputPath);
+            })
+            .catch(error => {this.setState({ error: "can't run renku command", computing: false })});
+    }
+
+    buildFullPath(partialPath: string) {
+        return this.props.app.info.directories.serverRoot + "/" + partialPath;
+    }
+ 
+    openGraphLoop(path: string) {
+        // check if the file has already been created
+        this.props.docManager.rename(RENKU_GRAPH_PATH, RENKU_GRAPH_PATH)
+            .then(data => { 
+                const graph = this.props.docManager.open(RENKU_GRAPH_PATH);
+                this.props.app.shell.addToMainArea(graph);
+                this.setState({ computing: false });
+            })
+            .catch(error => {
+                // timeout after a few loops
+                const loopCounter = this.state.loopCounter + 1;
+                if (loopCounter >= 50) {
+                    this.setState({ error: "graph creation timeout", computing: false});
+                    return;
+                }
+                this.setState({ loopCounter });
+                setTimeout(() => {this.openGraphLoop(path)}, 1000);
+            });
+    }
+
+    render() {
+        const currentFile = this.state.currentFile === null ?
+            "none" :
+            this.state.currentFile.type === "directory" ?
+                "invalid (directory)" :
+                this.state.currentFile.path;
+        const disabledButton = this.state.currentFile === null || this.state.currentFile.type === "directory" || this.state.computing ?
+            true : false;
+        const error = this.state.error ?
+            <span className="error-text">Error: {this.state.error}</span> :
+            null
+
+        return [
+            <li key="graphButton" className="p-CommandPalette-item" onClick={this.toggleVisibility}>
+                <div className={"p-CommandPalette-itemIcon jp-" + (this.state.visible ? "closed" : "opened") + "TabElement" }></div>
+                <div className="p-CommandPalette-itemContent">
+                    <div className="p-CommandPalette-itemLabel">Compute Lineage</div>
+                </div>
+            </li>,
+            <div key="graphInfo" className={!this.state.visible ? " jp-display-none" : ""}>
+                <li key="graphInfo" className="p-CommandPalette-item rk-innerTabElement">
+                <div className="p-CommandPalette-itemIcon"></div>
+                <div className="rk-argumentsForm">
+                        <div>
+                            Current file
+                            <textarea rows={2} className="jp-textEditorTabBar rk-innerTabTextArea"
+                                value={currentFile} onClick={this.activateFileBrowser}
+                                onChange={() => {}} readOnly />
+                            {error}
+                        </div>
+                        <button onClick={this.graphGenerator} disabled={disabledButton}>
+                            {this.state.computing ? "Creating graph..." : "Show Graph"}
+	                    </button>
+                    </div>
+                </li>
+            </div>
+            
+        ];
+    }
+} export { RenkuGraph };

--- a/src/RenkuTabBar.tsx
+++ b/src/RenkuTabBar.tsx
@@ -8,6 +8,7 @@ import '../style/index.css';
 
 import { JupyterLab } from '@jupyterlab/application';
 import { INotebookTracker } from '@jupyterlab/notebook';
+import { DocumentManager } from '@jupyterlab/docmanager';
 import RenkuCommands, { HelpCommands } from './RenkuCommands';
 import { GitCommands, DatasetCommands } from './RenkuCommands';
 import RenkuTerminalManager from './RenkuTerminalManager';
@@ -16,6 +17,7 @@ export interface IRenkuTabBar {
   app: JupyterLab;
   notebooks: INotebookTracker;
   terminalManager : RenkuTerminalManager;
+  docManager: DocumentManager;
 };
 
 class RenkuTabBar extends TabBar<void>{
@@ -62,7 +64,8 @@ class RenkuTabBar extends TabBar<void>{
         {
           app: this.props.app,
           notebooks: this.props.notebooks,
-          terminalManager: this.props.terminalManager
+          terminalManager: this.props.terminalManager,
+          docManager: this.props.docManager
         }),
       document.getElementById('renku-tab-content')
     );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,18 +1,31 @@
 import RenkuTabBar from './RenkuTabBar';
 import RenkuTerminalManager from './RenkuTerminalManager';
-import {
-  ILayoutRestorer,
-  JupyterLabPlugin,
-  JupyterLab
-} from '@jupyterlab/application';
-
+import { ILayoutRestorer, JupyterLabPlugin, JupyterLab } from '@jupyterlab/application';
 import { INotebookTracker } from '@jupyterlab/notebook';
 import { ITerminalTracker } from '@jupyterlab/terminal';
+import { DocumentManager } from '@jupyterlab/docmanager';
+import { DocumentWidget } from '@jupyterlab/docregistry';
 
 function activate(app: JupyterLab, restorer: ILayoutRestorer, notebooks: INotebookTracker) {
   const { shell } = app;
-  const terminalManager = new RenkuTerminalManager({ app: app, notebooks: notebooks });
-  const tabs = new RenkuTabBar({ app: app, notebooks: notebooks, terminalManager: terminalManager });
+  const terminalManager = new RenkuTerminalManager({
+    app: app,
+    notebooks: notebooks
+  });
+
+  let opener = {open: (widget: DocumentWidget) => { }};
+  let docManager = new DocumentManager({
+      registry: app.docRegistry,
+      manager: app.serviceManager,
+      opener
+  });
+  const tabs = new RenkuTabBar({
+    app: app,
+    notebooks: notebooks,
+    terminalManager: terminalManager,
+    docManager: docManager
+  });
+
   shell.addToLeftArea(tabs, { rank: 600 });
 };
 

--- a/style/index.css
+++ b/style/index.css
@@ -71,7 +71,6 @@
 }
 
 .rk-innerTabElement{
-    padding-right: 24px;
     background: var(--jp-layout-color2);
     border-top: var(--jp-border-width) solid var(--jp-border-color0);
     border-bottom: var(--jp-border-width) solid var(--jp-border-color0);
@@ -122,8 +121,7 @@
 }
 
 .rk-argumentsForm{
-    padding-right:8px;
-    padding-left:8px;
+    padding: 0;
     font-weight:100;
     width: 100%;
 }
@@ -149,7 +147,16 @@
     background-color: #262261;
 }
 
+.rk-argumentsForm button:disabled{
+    background-color: #cccccc;
+}
+
 .rk-argumentsForm label{
     color: var(--jp-ui-font-color1);
     font-size: var(--jp-ui-font-size1);
+}
+
+.rk-argumentsForm .error-text{
+    color: #F44336;
+    font-style: italic;
 }


### PR DESCRIPTION
fix #13

This adds the possibility to create a lineage graph for any file selected in the File Browser left tab.

![Screenshot from 2019-06-28 12-08-08](https://user-images.githubusercontent.com/43481553/60335172-7c8c5e80-999d-11e9-8b56-11b3b71b9472.png)

The base image must include `graphviz` to be able to create the graph images from the command line (already added here SwissDataScienceCenter/renku-jupyter#36) 